### PR TITLE
Filter subagent mode agents from agent picker

### DIFF
--- a/src/hooks/useOpenCode.ts
+++ b/src/hooks/useOpenCode.ts
@@ -189,6 +189,7 @@ interface Agent {
   name: string;
   description?: string;
   id?: string;
+  mode?: "primary" | "subagent" | "all";
 }
 
 interface ProjectResponse {
@@ -2080,9 +2081,12 @@ export function useOpenCode() {
     if (loadedAgentsRef.current) return;
     try {
       const response = await openCodeService.getAgents();
-      const agentsArray: Agent[] = Array.isArray(response.data)
+      const allAgents: Agent[] = Array.isArray(response.data)
         ? response.data
         : [];
+      const agentsArray = allAgents.filter(
+        (agent) => agent.mode === "primary" || agent.mode === "all" || !agent.mode
+      );
       setAgents(agentsArray);
       loadedAgentsRef.current = true;
 


### PR DESCRIPTION
Fixes #13 

Only show agents with mode 'primary', 'all', or undefined in the UI to prevent subagents from appearing in the main agent selection picker. This declutters the interface and ensures users only see agents intended for direct interaction.

According to opencode docs: "The mode option can be set to primary, subagent, or all. If no mode is specified, it defaults to all."

Before:
<img width="1910" height="964" alt="image" src="https://github.com/user-attachments/assets/43ac8b0d-a0dc-4f69-9b06-9ff010c7eb95" />

After:
<img width="461" height="304" alt="image" src="https://github.com/user-attachments/assets/43ab48f5-170a-4218-82bb-cdf68bea0863" />
