### PR TITLE
Fix session timestamp conversion causing incorrect dates in sidebar

### DIFF
--- a/src/hooks/useOpenCode.ts
+++ b/src/hooks/useOpenCode.ts
@@ -1497,10 +1497,10 @@ export function useOpenCode() {
         directory: session.directory,
         projectID: session.projectID || currentProject?.id,
         createdAt: session.time?.created
-          ? new Date(session.time.created * 1000)
+          ? new Date(session.time.created)
           : undefined,
         updatedAt: session.time?.updated
-          ? new Date(session.time.updated * 1000)
+          ? new Date(session.time.updated)
           : undefined,
         messageCount: undefined,
       }));
@@ -1624,10 +1624,10 @@ export function useOpenCode() {
         directory: session.directory,
         projectID: session.projectID || project.id, // Ensure projectID is set
         createdAt: session.time?.created
-          ? new Date(session.time.created * 1000)
+          ? new Date(session.time.created)
           : undefined,
         updatedAt: session.time?.updated
-          ? new Date(session.time.updated * 1000)
+          ? new Date(session.time.updated)
           : undefined,
         messageCount: undefined,
       }));


### PR DESCRIPTION
Fixes #21 

Master: 
<img width="297" height="168" alt="image" src="https://github.com/user-attachments/assets/8d73e0a3-ce62-49a5-ba85-54563471eca2" />

This branch:
<img width="280" height="94" alt="image" src="https://github.com/user-attachments/assets/b60df543-4534-4482-ba2d-8213b60f4d36" />



---

Credit to sonnet 4.5 for this tbh:
"I'm investigating a bug where the Session dates on the left hand side seem very wrong when the page is loaded. Any ideas?"

# Summary

## Issue Identified
User reported a bug where session dates displayed on the left-hand sidebar appeared incorrect (very wrong dates) when the page loaded.

## Root Cause Found
Located the bug in `/root/repos/opencode-web/src/hooks/useOpenCode.ts`:
- Lines 1503-1508 (`loadSessions` function)
- Lines 1630-1635 (`switchProject` function)

Both locations were incorrectly multiplying `time.created` and `time.updated` timestamps by 1000, assuming the OpenCode API returns Unix timestamps in **seconds**. However, the API actually returns timestamps already in **milliseconds**.

This caused dates to be displayed far in the future (e.g., multiplying a 2024 millisecond timestamp by 1000 would result in a date thousands of years ahead).

## Fix Applied
Removed the `* 1000` multiplication in two locations:

1. **Line 1504-1508** in `loadSessions`:
   - Changed `new Date(session.time.created * 1000)` → `new Date(session.time.created)`
   - Changed `new Date(session.time.updated * 1000)` → `new Date(session.time.updated)`

2. **Line 1631-1635** in `switchProject`:
   - Applied the same fix for session timestamp conversion

## Files Modified
- `/root/repos/opencode-web/src/hooks/useOpenCode.ts` (2 edits)

## Next Steps
- Test the fix by reloading the application and verifying session dates display correctly
- The same pattern might exist for project timestamps (lines 1458-1463, 1261-1266) which also multiply by 1000, but those may be correct if projects use a different timestamp format