### PR TITLE
Improve sidebar toggle behavior and fix UI glitches

### DIFF
--- a/src/app/_components/message/PrettyDiff.tsx
+++ b/src/app/_components/message/PrettyDiff.tsx
@@ -16,7 +16,7 @@ function looksUnified(diff: string) {
 }
 
 export function PrettyDiff({ diffText }: PrettyDiffProps) {
-  const [view, setView] = useState<"line-by-line" | "side-by-side">("line-by-line");
+  const [view, setView] = useState<"line-by-line" | "side-by-side">("side-by-side");
   const [open, setOpen] = useState<Set<number>>(new Set([0]));
 
   const content = useMemo(() => {


### PR DESCRIPTION
## Summary

This PR improves the sidebar toggle behavior and fixes UI glitches in the top toolbar.

## Changes

### Sidebar Toggle Improvements
- Clicking an active tab (Workspace/Files) now hides the left sidebar
- When no sidebars are visible, all tab buttons appear inactive
- Added localStorage persistence for left sidebar visibility state

### Status Button Fix
- Fixed status button indicator to show correct active/inactive state
- Now shows active (foreground0) when sidebar is open, inactive (foreground1) when closed
- Removed redundant "Hide" button from status sidebar panel

### UI Glitch Fix
- Fixed layout shifting in top toolbar when toggling status sidebar
- Stabilized badge and tab positioning with proper flex constraints
- Added `flex-shrink-0` to prevent unwanted element shrinking
- Added `overflow-hidden` to parent container for stable layout

### Bonus
- Changed diff viewer default from line-by-line to side-by-side view

## Testing

All changes tested with successful build. The UI now remains stable when toggling sidebars and tab states correctly reflect sidebar visibility.